### PR TITLE
Move from HTCP to BBR for tcp congestion control

### DIFF
--- a/sysctl.conf
+++ b/sysctl.conf
@@ -33,6 +33,7 @@
 # http://www.speedguide.net/read_articles.php?id=121
 # http://lartc.org/howto/lartc.kernel.obscure.html
 # http://en.wikipedia.org/wiki/Sysctl
+# https://blog.cloudflare.com/http-2-prioritization-with-nginx/
 
 
 
@@ -187,10 +188,11 @@ net.ipv6.conf.eth0.accept_ra=0
 ### TUNING NETWORK PERFORMANCE ###
 ###
 
-# For high-bandwidth low-latency networks, use 'htcp' congestion control
-# Do a 'modprobe tcp_htcp' first
-net.ipv4.tcp_congestion_control = htcp
-
+# Use BBR TCP congestion control and set tcp_notsent_lowat to 16384 to ensure HTTP/2 prioritization works optimally
+# Do a 'modprobe tcp_bbr' first (kernel > 4.9)
+net.ipv4.tcp_congestion_control = bbr
+net.ipv4.tcp_notsent_lowat = 16384
+    
 # For servers with tcp-heavy workloads, enable 'fq' queue management scheduler (kernel > 3.12)
 net.core.default_qdisc = fq
 


### PR DESCRIPTION
Move from HTCP to BBR for TCP congestion control per recommendations at https://blog.cloudflare.com/http-2-prioritization-with-nginx/

Available in Linux kernels 4.9+. A paper about BBR can be found at https://queue.acm.org/detail.cfm?id=3022184

Partially addresses #2 